### PR TITLE
Add missing option "r" to getopts

### DIFF
--- a/setup
+++ b/setup
@@ -33,7 +33,7 @@ print_usage() {
 	echo -e "y: Continue installation without prompts"
 }
 
-while getopts "B:b:l:P:p:y" flag; do
+while getopts "B:b:l:P:p:r:y" flag; do
 	case "${flag}" in
 		B) EFIBOOT="${OPTARG}" ;;
 		b) BOOT="${OPTARG}" ;;


### PR DESCRIPTION
The option "r" is in `print_usage` and `case` but is missing in the `getopts` command.